### PR TITLE
Fix circle rendering in Safari

### DIFF
--- a/css/circle.css
+++ b/css/circle.css
@@ -8,8 +8,8 @@
   top: var(--circle-y);
   transform: translate(-50%, -50%);
 
-  inline-size: var(--circle-diameter);
-  aspect-ratio: 1;
+  width: var(--circle-diameter);
+  height: var(--circle-diameter);
   border-radius: 50%;
 
   border: 1px solid var(--border-color);


### PR DESCRIPTION
Hi Dwayne, nicely done here.

I noticed this bug with Safari(1):

<img width="200" alt="Screen Shot 2023-08-09 at 6 41 02 PM" src="https://github.com/dwayne/elm-7guis/assets/61954617/c56e39fe-a174-4a28-b308-b4cbf96d523b">
<img width="200" alt="Screen Shot 2023-08-09 at 6 41 19 PM" src="https://github.com/dwayne/elm-7guis/assets/61954617/e908702c-9bad-4db0-807c-435f0e90d764">

...and am offering this here if you want it! Afterwards:

<img width="200" alt="Screen Shot 2023-08-09 at 6 42 50 PM" src="https://github.com/dwayne/elm-7guis/assets/61954617/b9f60e9d-27ed-4ef5-943a-fdb784f430da">

1. Version 16.6 (18615.3.12.11.2)
